### PR TITLE
Prediction at the end fails because of tokenizer padding

### DIFF
--- a/07_train/01_Train_Reviews_BERT_Transformers_TensorFlow_AdHoc.ipynb
+++ b/07_train/01_Train_Reviews_BERT_Transformers_TensorFlow_AdHoc.ipynb
@@ -431,7 +431,7 @@
     "sample_review_body = \"This product is terrible.\"\n",
     "\n",
     "encode_plus_tokens = tokenizer.encode_plus(\n",
-    "    sample_review_body, padding=True, max_length=max_seq_length, truncation=True, return_tensors=\"tf\"\n",
+    "    sample_review_body, padding='max_length', max_length=max_seq_length, truncation=True, return_tensors=\"tf\"\n",
     ")\n",
     "\n",
     "# The id from the pre-trained BERT vocabulary that represents the token.  (Padding of 0 will be used if the # of tokens is less than `max_seq_length`)\n",


### PR DESCRIPTION
Change the parameter to padding='max_length', so the inputs match the expected length of max_seq_length=64.